### PR TITLE
chore: release on workflow_dispatch

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -7,9 +7,8 @@ on:
     tags:
       - "!*" # not a tag push
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches:
+      - "master"
 
 jobs:
   build-dotnet:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -41,7 +41,10 @@ jobs:
       # with windows. image from https://hub.docker.com/r/gableroux/unity3d/tags
       image: gableroux/unity3d:${{ matrix.unity }}-windows
     steps:
-      - run: apt update && apt install git -y
+      # Ubuntu 18.04 git is too old, use ppa latest git.
+      - run: |
+          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
+          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -58,6 +58,16 @@ jobs:
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
         working-directory: src/RandomFixtureKit.Unity
 
+      - name: check all .meta is commited
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
+        working-directory: src/RandomFixtureKit.Unity
+
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -27,6 +27,7 @@ jobs:
       - run: dotnet test -c Debug --no-build
 
   build-unity:
+    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
         unity: ["2019.3.9f1", "2020.1.0b5"]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -84,6 +84,7 @@ jobs:
           path: ./publish
 
   build-unity:
+    needs: [update-packagejson]
     strategy:
       matrix:
         unity: ["2019.3.9f1"]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,6 +12,8 @@ on:
         default: "false"
 
 env:
+  GIT_TAG: ${{ github.event.inputs.tag }}
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
   DRY_RUN_BRANCH_PREFIX: "test_release"
   DOTNET_SDK_VERISON_3: 3.1.x
 
@@ -19,9 +21,7 @@ jobs:
   update-packagejson:
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       TARGET_FILE: ./src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/package.json
-      DRY_RUN: ${{ github.event.inputs.dry_run }}
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
     steps:
@@ -43,12 +43,15 @@ jobs:
         run: echo "SHA ${SHA}"
         env:
           SHA: ${{ steps.commit.outputs.sha }}
+      - name: tag
+        run: git tag ${{ env.GIT_TAG }}
+        if: env.DRY_RUN == 'false'
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
-          tags: false
+          tags: true
         if: env.DRY_RUN == 'false'
       - name: Push changes (dry_run)
         uses: ad-m/github-push-action@master
@@ -63,11 +66,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
     steps:
+      - run: echo ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
@@ -91,8 +94,6 @@ jobs:
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
-    env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
@@ -124,6 +125,16 @@ jobs:
         env:
           UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
 
+      - name: check all .meta is commited
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
+        working-directory: src/RandomFixtureKit.Unity
+
       # Store artifacts.
       - uses: actions/upload-artifact@v2
         with:
@@ -132,10 +143,9 @@ jobs:
 
   create-release:
     if: github.event.inputs.dry_run == 'false'
-    needs: [build-dotnet, build-unity]
+    needs: [update-packagejson, build-dotnet, build-unity]
     runs-on: ubuntu-latest
     env:
-      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -144,14 +154,17 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
-      # Create Releases
+      # Create Release
       - uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Ver.${{ github.ref }}
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: Ver.${{ env.GIT_TAG }}
+          commitish: ${{ needs.update-packagejson.outputs.sha }}
+          draft: true
+          prerelease: false
       # Download (All) Artifacts to current directory
       - uses: actions/download-artifact@v2
       # Upload to NuGet

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,25 +1,79 @@
 name: Build-Release
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag: git tag you want create. (sample 1.0.0)"
+        required: true
+      dry_run:
+        description: "dry_run: true will never create relase/nuget."
+        required: true
+        default: "false"
+
+env:
+  DRY_RUN_BRANCH_PREFIX: "test_release"
+  DOTNET_SDK_VERISON_3: 3.1.x
 
 jobs:
-  build-dotnet:
+  update-packagejson:
     runs-on: ubuntu-latest
     env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
+      TARGET_FILE: ./src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/package.json
+      DRY_RUN: ${{ github.event.inputs.dry_run }}
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: before
+        run: cat ${{ env.TARGET_FILE}}
+      - name: update package.json to version ${{ env.GIT_TAG }}
+        run: sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ env.GIT_TAG }}\",/" ${{ env.TARGET_FILE }}
+      - name: after
+        run: cat ${{ env.TARGET_FILE}}
+      - name: Commit files
+        id: commit
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "feat: Update package.json to ${{ env.GIT_TAG }}" -a
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+      - name: check sha
+        run: echo "SHA ${SHA}"
+        env:
+          SHA: ${{ steps.commit.outputs.sha }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: false
+        if: env.DRY_RUN == 'false'
+      - name: Push changes (dry_run)
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
+          tags: false
+        if: env.DRY_RUN == 'true'
+
+  build-dotnet:
+    needs: [update-packagejson]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
+          dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
       - run: dotnet test -c Release --no-build -p:Version=${{ env.GIT_TAG }}
@@ -36,20 +90,26 @@ jobs:
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
+    env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      - run: apt update && apt install git -y
+      # Ubuntu 18.04 git is too old, use ppa latest git.
+      - run: |
+          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
+          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
+      # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
       - run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
-
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Build Windows(Mono)
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod UnitTestBuilder.BuildUnitTest /headless /ScriptBackend Mono2x /BuildTarget StandaloneLinux64
@@ -70,9 +130,11 @@ jobs:
           path: ./src/RandomFixtureKit.Unity/RandomFixtureKit.Unity.${{ env.GIT_TAG }}.unitypackage
 
   create-release:
+    if: github.event.inputs.dry_run == 'false'
     needs: [build-dotnet, build-unity]
     runs-on: ubuntu-latest
     env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
@@ -80,10 +142,7 @@ jobs:
       # setup dotnet for nuget push
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
+          dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
       # Create Releases
       - uses: actions/create-release@v1
         id: create_release
@@ -92,19 +151,29 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Ver.${{ github.ref }}
-
       # Download (All) Artifacts to current directory
       - uses: actions/download-artifact@v2
-
       # Upload to NuGet
       - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-
       # Upload to Releases(unitypackage)
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./RandomFixtureKit.Unity.${{ env.GIT_TAG }}.unitypackage/MasterMemory.Unity.${{ env.GIT_TAG }}.unitypackage
+          asset_path: ./RandomFixtureKit.Unity.${{ env.GIT_TAG }}.unitypackage/RandomFixtureKit.Unity.${{ env.GIT_TAG }}.unitypackage
           asset_name: RandomFixtureKit.Unity.${{ env.GIT_TAG }}.unitypackage
           asset_content_type: application/octet-stream
+
+  cleanup:
+    if: github.event.inputs.dry_run == 'true'
+    needs: [build-dotnet, build-unity]
+    runs-on: ubuntu-latest
+    env:
+      GIT_TAG: ${{ github.event.inputs.tag }}
+    steps:
+      - name: Delete branch
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ github.token }}
+          branches: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}


### PR DESCRIPTION
## TL;DR

* Change release flow from `tag push` to `worlkflow dispatch`.This enable `dry_run` to create package before tag/release.
* add .meta commit missing detection on ci.
* debug build on `master` branch push/pr only.

## Change

* before: tag version `1.0.0` and push to origin will start release github actions.
* after: go to github actions -> build-release -> Workflow dispatch -> set `tag` & `dry_run`.
