### PR TITLE
fix: make recursive count works with tree structure

### DIFF
--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit.Tests/Tests/TreeStructureTest.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit.Tests/Tests/TreeStructureTest.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace RandomFixtureKit.Tests
+{
+    public class TreeStructureTest
+    {
+        [Fact]
+        public void CheckArray()
+        {
+            FixtureFactory.Create<ArrayTreeNode>();
+        }
+
+        [Fact]
+        public void CheckArraySegment() {
+            FixtureFactory.Create<ArraySegmentTreeNode>();
+        }
+
+        [Fact]
+        public void CheckList() {
+            FixtureFactory.Create<ListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckLinkedList() {
+            FixtureFactory.Create<LinkedListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckStack() {
+            FixtureFactory.Create<StackTreeNode>();
+        }
+
+        [Fact]
+        public void CheckQueue() {
+            FixtureFactory.Create<QueueTreeNode>();
+        }
+
+        [Fact]
+        public void CheckConcurrentQueue() {
+            FixtureFactory.Create<ConcurrentQueueTreeNode>();
+        }
+
+        [Fact]
+        public void CheckConcurrentStack() {
+            FixtureFactory.Create<ConcurrentStackTreeNode>();
+        }
+
+        [Fact]
+        public void CheckICollection() {
+            FixtureFactory.Create<ICollectionTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIEnumerable() {
+            FixtureFactory.Create<IEnumerableTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIList() {
+            FixtureFactory.Create<IListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIReadOnlyCollection() {
+            FixtureFactory.Create<IReadOnlyCollectionTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIReadOnlyList() {
+            FixtureFactory.Create<IReadOnlyListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckDictionary() {
+            FixtureFactory.Create<DictionaryTreeNode>();
+        }
+
+        [Fact]
+        public void CheckSortedDictionary() {
+            FixtureFactory.Create<SortedDictionaryTreeNode>();
+        }
+
+        [Fact]
+        public void CheckSortedList() {
+            FixtureFactory.Create<SortedListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIDictionary() {
+            FixtureFactory.Create<IDictionaryTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIReadOnlyDictionary() {
+            FixtureFactory.Create<IReadOnlyDictionaryTreeNode>();
+        }
+
+        }
+
+
+    class ArrayTreeNode
+    {
+        public string Name { get; set; }
+        public ArrayTreeNode[] Children { get; set; }
+    }
+
+    
+    class ArraySegmentTreeNode {
+        public string Name { get; set; }
+        public ArraySegment<ArraySegmentTreeNode> Children { get; set; }
+    }
+    
+    class ListTreeNode {
+        public string Name { get; set; }
+        public List<ListTreeNode> Children { get; set; }
+    }
+    
+    class LinkedListTreeNode {
+        public string Name { get; set; }
+        public LinkedList<LinkedListTreeNode> Children { get; set; }
+    }
+    
+    class StackTreeNode {
+        public string Name { get; set; }
+        public Stack<StackTreeNode> Children { get; set; }
+    }
+    
+    class QueueTreeNode {
+        public string Name { get; set; }
+        public Queue<QueueTreeNode> Children { get; set; }
+    }
+    
+    class ConcurrentQueueTreeNode {
+        public string Name { get; set; }
+        public ConcurrentQueue<ConcurrentQueueTreeNode> Children { get; set; }
+    }
+    
+    class ConcurrentStackTreeNode {
+        public string Name { get; set; }
+        public ConcurrentStack<ConcurrentStackTreeNode> Children { get; set; }
+    }
+    
+    class ICollectionTreeNode {
+        public string Name { get; set; }
+        public ICollection<ICollectionTreeNode> Children { get; set; }
+    }
+    
+    class IEnumerableTreeNode {
+        public string Name { get; set; }
+        public IEnumerable<IEnumerableTreeNode> Children { get; set; }
+    }
+    
+    class IListTreeNode {
+        public string Name { get; set; }
+        public IList<IListTreeNode> Children { get; set; }
+    }
+    
+    class IReadOnlyCollectionTreeNode {
+        public string Name { get; set; }
+        public IReadOnlyCollection<IReadOnlyCollectionTreeNode> Children { get; set; }
+    }
+    
+    class IReadOnlyListTreeNode {
+        public string Name { get; set; }
+        public IReadOnlyList<IReadOnlyListTreeNode> Children { get; set; }
+    }
+    
+    
+    class DictionaryTreeNode {
+        public string Name { get; set; }
+        public Dictionary<string, DictionaryTreeNode> Children { get; set; }
+    }
+    
+    class SortedDictionaryTreeNode {
+        public string Name { get; set; }
+        public SortedDictionary<string, SortedDictionaryTreeNode> Children { get; set; }
+    }
+    
+    class SortedListTreeNode {
+        public string Name { get; set; }
+        public SortedList<string, SortedListTreeNode> Children { get; set; }
+    }
+    
+    class IDictionaryTreeNode {
+        public string Name { get; set; }
+        public IDictionary<string, IDictionaryTreeNode> Children { get; set; }
+    }
+    
+    class IReadOnlyDictionaryTreeNode {
+        public string Name { get; set; }
+        public IReadOnlyDictionary<string, IReadOnlyDictionaryTreeNode> Children { get; set; }
+    }
+    }

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit.Tests/Tests/TreeStructureTest.cs.meta
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit.Tests/Tests/TreeStructureTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 785fe79c348e61d488f342ed6c7dc13c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Generators/CollectionGenerators.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Generators/CollectionGenerators.cs
@@ -19,22 +19,24 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = Type.GetElementType();
-            var generator = context.GetGenerator(elemType);
-            var rank = Type.GetArrayRank();
-
-            var array = Array.CreateInstance(elemType, Enumerable.Range(0, rank).Select(_ => length).ToArray());
-            switch (rank)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                case 1: SetOne(array, generator, context); break;
-                case 2: SetTwo(array, generator, context); break;
-                case 3: SetThree(array, generator, context); break;
-                default:
-                    throw new InvalidOperationException($"Array rank:{rank} is not supported.");
-            }
+                var elemType = Type.GetElementType();
+                var generator = context.GetGenerator(elemType);
+                var rank = Type.GetArrayRank();
 
-            return array;
+                var array = Array.CreateInstance(elemType, Enumerable.Range(0, rank).Select(_ => length).ToArray());
+                switch (rank)
+                {
+                    case 1: SetOne(array, generator, context); break;
+                    case 2: SetTwo(array, generator, context); break;
+                    case 3: SetThree(array, generator, context); break;
+                    default:
+                        throw new InvalidOperationException($"Array rank:{rank} is not supported.");
+                }
+
+                return array;
+            }
         }
 
         void SetOne(Array array, IGenerator generator, GenerationContext context)
@@ -86,12 +88,14 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = type.GetGenericArguments()[0];
-            var arrayGenerator = context.GetGenerator(elemType.MakeArrayType());
+            using (var scope = context.TypeStack.Enter(Type))
+            {
+                var elemType = type.GetGenericArguments()[0];
+                var arrayGenerator = context.GetGenerator(elemType.MakeArrayType());
 
-            var innerArray = arrayGenerator.Generate(context);
-            return ReflectionHelper.CreateInstance(type, new[] { innerArray });
+                var innerArray = arrayGenerator.Generate(context);
+                return ReflectionHelper.CreateInstance(type, new[] { innerArray });
+            }
         }
     }
 
@@ -111,17 +115,19 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = type.GetGenericArguments()[0];
-            var generator = context.GetGenerator(elemType);
-
-            var list = ReflectionHelper.CreateInstance(type) as IList;
-            for (int i = 0; i < length; i++)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                list.Add(generator.Generate(context));
-            }
+                var elemType = type.GetGenericArguments()[0];
+                var generator = context.GetGenerator(elemType);
 
-            return list;
+                var list = ReflectionHelper.CreateInstance(type) as IList;
+                for (int i = 0; i < length; i++)
+                {
+                    list.Add(generator.Generate(context));
+                }
+
+                return list;
+            }
         }
     }
 
@@ -141,20 +147,22 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            var genArgs = type.GetGenericArguments();
-            var keyType = genArgs[0];
-            var valueType = genArgs[1];
-            var keyGenerator = context.GetGenerator(keyType);
-            var valueGenerator = context.GetGenerator(valueType);
-            context.TypeStack.Enter(Type);
-
-            var dict = ReflectionHelper.CreateInstance(type) as IDictionary;
-            for (int i = 0; i < length; i++)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                dict[keyGenerator.Generate(context)] = valueGenerator.Generate(context);
-            }
+                var genArgs = type.GetGenericArguments();
+                var keyType = genArgs[0];
+                var valueType = genArgs[1];
+                var keyGenerator = context.GetGenerator(keyType);
+                var valueGenerator = context.GetGenerator(valueType);
 
-            return dict;
+                var dict = ReflectionHelper.CreateInstance(type) as IDictionary;
+                for (int i = 0; i < length; i++)
+                {
+                    dict[keyGenerator.Generate(context)] = valueGenerator.Generate(context);
+                }
+
+                return dict;
+            }
         }
     }
 
@@ -173,19 +181,21 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = Type.GetGenericArguments()[0];
-            var generator = context.GetGenerator(elemType);
-
-            var add = Type.GetMethod(AddMethodName, new[] { elemType });
-
-            var collection = ReflectionHelper.CreateInstance(Type);
-            for (int i = 0; i < length; i++)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                add.Invoke(collection, new[] { generator.Generate(context) });
-            }
+                var elemType = Type.GetGenericArguments()[0];
+                var generator = context.GetGenerator(elemType);
 
-            return collection;
+                var add = Type.GetMethod(AddMethodName, new[] { elemType });
+
+                var collection = ReflectionHelper.CreateInstance(Type);
+                for (int i = 0; i < length; i++)
+                {
+                    add.Invoke(collection, new[] { generator.Generate(context) });
+                }
+
+                return collection;
+            }
         }
     }
 
@@ -254,13 +264,15 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var genType = type.GenericTypeArguments;
-            var generator = context.GetGenerator(typeof(Dictionary<,>).MakeGenericType(new[] { genType[0], genType[1].MakeArrayType() }));
-            var dictionary = generator.Generate(context);
+            using (var scope = context.TypeStack.Enter(Type))
+            {
+                var genType = type.GenericTypeArguments;
+                var generator = context.GetGenerator(typeof(Dictionary<,>).MakeGenericType(new[] { genType[0], genType[1].MakeArrayType() }));
+                var dictionary = generator.Generate(context);
 
-            var lookup = ReflectionHelper.CreateInstance(typeof(PseudoLookup<,>).MakeGenericType(genType), new[] { dictionary });
-            return lookup;
+                var lookup = ReflectionHelper.CreateInstance(typeof(PseudoLookup<,>).MakeGenericType(genType), new[] { dictionary });
+                return lookup;
+            }
         }
 
         // require to type hint to use in IL2CPP

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Generators/CollectionGenerators.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Generators/CollectionGenerators.cs
@@ -19,6 +19,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = Type.GetElementType();
             var generator = context.GetGenerator(elemType);
             var rank = Type.GetArrayRank();
@@ -85,6 +86,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = type.GetGenericArguments()[0];
             var arrayGenerator = context.GetGenerator(elemType.MakeArrayType());
 
@@ -109,6 +111,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = type.GetGenericArguments()[0];
             var generator = context.GetGenerator(elemType);
 
@@ -143,6 +146,7 @@ namespace RandomFixtureKit.Generators
             var valueType = genArgs[1];
             var keyGenerator = context.GetGenerator(keyType);
             var valueGenerator = context.GetGenerator(valueType);
+            context.TypeStack.Enter(Type);
 
             var dict = ReflectionHelper.CreateInstance(type) as IDictionary;
             for (int i = 0; i < length; i++)
@@ -169,6 +173,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = Type.GetGenericArguments()[0];
             var generator = context.GetGenerator(elemType);
 
@@ -249,6 +254,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var genType = type.GenericTypeArguments;
             var generator = context.GetGenerator(typeof(Dictionary<,>).MakeGenericType(new[] { genType[0], genType[1].MakeArrayType() }));
             var dictionary = generator.Generate(context);

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Generators/ObjectGenerator.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Generators/ObjectGenerator.cs
@@ -19,8 +19,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            var scope = context.TypeStack.Enter(type);
-            try
+            using (var scope = context.TypeStack.Enter(type))
             {
                 var obj = FormatterServices.GetUninitializedObject(type);
 
@@ -37,10 +36,6 @@ namespace RandomFixtureKit.Generators
                 }
 
                 return obj;
-            }
-            finally
-            {
-                scope.Dispose();
             }
         }
     }

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Interfaces.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Interfaces.cs
@@ -36,7 +36,7 @@ namespace RandomFixtureKit
         }
     }
 
-    public readonly ref struct TypeStack
+    public readonly struct TypeStack
     {
         readonly Stack<Type> stack;
 
@@ -63,7 +63,7 @@ namespace RandomFixtureKit
             return c;
         }
 
-        public readonly ref struct Exit // : IDisposable
+        public readonly struct Exit: IDisposable
         {
             readonly TypeStack parent;
 

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Interfaces.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/Interfaces.cs
@@ -58,7 +58,7 @@ namespace RandomFixtureKit
             var c = 0;
             foreach (var item in stack)
             {
-                if (item == type) c++;
+                if (type.IsAssignableFrom(item)) c++;
             }
             return c;
         }

--- a/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/RandomProvider.cs
+++ b/src/RandomFixtureKit.Unity/Assets/Scripts/RandomFixtureKit/RandomProvider.cs
@@ -54,10 +54,10 @@ namespace RandomFixtureKit
             //for more information.
             //In the worst case, the expected number of calls is 2 (though usually it's
             //much closer to 1) so this loop doesn't really hurt performance at all.
+            byte[] buf = new byte[8];
             ulong ulongRand;
             do
             {
-                byte[] buf = new byte[8];
                 random.NextBytes(buf);
                 ulongRand = (ulong)BitConverter.ToInt64(buf, 0);
             } while (ulongRand > ulong.MaxValue - ((ulong.MaxValue % uRange) + 1) % uRange);

--- a/src/RandomFixtureKit/Generators/CollectionGenerators.cs
+++ b/src/RandomFixtureKit/Generators/CollectionGenerators.cs
@@ -19,22 +19,24 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = Type.GetElementType();
-            var generator = context.GetGenerator(elemType);
-            var rank = Type.GetArrayRank();
-
-            var array = Array.CreateInstance(elemType, Enumerable.Range(0, rank).Select(_ => length).ToArray());
-            switch (rank)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                case 1: SetOne(array, generator, context); break;
-                case 2: SetTwo(array, generator, context); break;
-                case 3: SetThree(array, generator, context); break;
-                default:
-                    throw new InvalidOperationException($"Array rank:{rank} is not supported.");
-            }
+                var elemType = Type.GetElementType();
+                var generator = context.GetGenerator(elemType);
+                var rank = Type.GetArrayRank();
 
-            return array;
+                var array = Array.CreateInstance(elemType, Enumerable.Range(0, rank).Select(_ => length).ToArray());
+                switch (rank)
+                {
+                    case 1: SetOne(array, generator, context); break;
+                    case 2: SetTwo(array, generator, context); break;
+                    case 3: SetThree(array, generator, context); break;
+                    default:
+                        throw new InvalidOperationException($"Array rank:{rank} is not supported.");
+                }
+
+                return array;
+            }
         }
 
         void SetOne(Array array, IGenerator generator, GenerationContext context)
@@ -86,12 +88,14 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = type.GetGenericArguments()[0];
-            var arrayGenerator = context.GetGenerator(elemType.MakeArrayType());
+            using (var scope = context.TypeStack.Enter(Type))
+            {
+                var elemType = type.GetGenericArguments()[0];
+                var arrayGenerator = context.GetGenerator(elemType.MakeArrayType());
 
-            var innerArray = arrayGenerator.Generate(context);
-            return ReflectionHelper.CreateInstance(type, new[] { innerArray });
+                var innerArray = arrayGenerator.Generate(context);
+                return ReflectionHelper.CreateInstance(type, new[] { innerArray });
+            }
         }
     }
 
@@ -111,17 +115,19 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = type.GetGenericArguments()[0];
-            var generator = context.GetGenerator(elemType);
-
-            var list = ReflectionHelper.CreateInstance(type) as IList;
-            for (int i = 0; i < length; i++)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                list.Add(generator.Generate(context));
-            }
+                var elemType = type.GetGenericArguments()[0];
+                var generator = context.GetGenerator(elemType);
 
-            return list;
+                var list = ReflectionHelper.CreateInstance(type) as IList;
+                for (int i = 0; i < length; i++)
+                {
+                    list.Add(generator.Generate(context));
+                }
+
+                return list;
+            }
         }
     }
 
@@ -141,20 +147,22 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            var genArgs = type.GetGenericArguments();
-            var keyType = genArgs[0];
-            var valueType = genArgs[1];
-            var keyGenerator = context.GetGenerator(keyType);
-            var valueGenerator = context.GetGenerator(valueType);
-            context.TypeStack.Enter(Type);
-
-            var dict = ReflectionHelper.CreateInstance(type) as IDictionary;
-            for (int i = 0; i < length; i++)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                dict[keyGenerator.Generate(context)] = valueGenerator.Generate(context);
-            }
+                var genArgs = type.GetGenericArguments();
+                var keyType = genArgs[0];
+                var valueType = genArgs[1];
+                var keyGenerator = context.GetGenerator(keyType);
+                var valueGenerator = context.GetGenerator(valueType);
 
-            return dict;
+                var dict = ReflectionHelper.CreateInstance(type) as IDictionary;
+                for (int i = 0; i < length; i++)
+                {
+                    dict[keyGenerator.Generate(context)] = valueGenerator.Generate(context);
+                }
+
+                return dict;
+            }
         }
     }
 
@@ -173,19 +181,21 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var elemType = Type.GetGenericArguments()[0];
-            var generator = context.GetGenerator(elemType);
-
-            var add = Type.GetMethod(AddMethodName, new[] { elemType });
-
-            var collection = ReflectionHelper.CreateInstance(Type);
-            for (int i = 0; i < length; i++)
+            using (var scope = context.TypeStack.Enter(Type))
             {
-                add.Invoke(collection, new[] { generator.Generate(context) });
-            }
+                var elemType = Type.GetGenericArguments()[0];
+                var generator = context.GetGenerator(elemType);
 
-            return collection;
+                var add = Type.GetMethod(AddMethodName, new[] { elemType });
+
+                var collection = ReflectionHelper.CreateInstance(Type);
+                for (int i = 0; i < length; i++)
+                {
+                    add.Invoke(collection, new[] { generator.Generate(context) });
+                }
+
+                return collection;
+            }
         }
     }
 
@@ -254,13 +264,15 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            context.TypeStack.Enter(Type);
-            var genType = type.GenericTypeArguments;
-            var generator = context.GetGenerator(typeof(Dictionary<,>).MakeGenericType(new[] { genType[0], genType[1].MakeArrayType() }));
-            var dictionary = generator.Generate(context);
+            using (var scope = context.TypeStack.Enter(Type))
+            {
+                var genType = type.GenericTypeArguments;
+                var generator = context.GetGenerator(typeof(Dictionary<,>).MakeGenericType(new[] { genType[0], genType[1].MakeArrayType() }));
+                var dictionary = generator.Generate(context);
 
-            var lookup = ReflectionHelper.CreateInstance(typeof(PseudoLookup<,>).MakeGenericType(genType), new[] { dictionary });
-            return lookup;
+                var lookup = ReflectionHelper.CreateInstance(typeof(PseudoLookup<,>).MakeGenericType(genType), new[] { dictionary });
+                return lookup;
+            }
         }
 
         // require to type hint to use in IL2CPP

--- a/src/RandomFixtureKit/Generators/CollectionGenerators.cs
+++ b/src/RandomFixtureKit/Generators/CollectionGenerators.cs
@@ -19,6 +19,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = Type.GetElementType();
             var generator = context.GetGenerator(elemType);
             var rank = Type.GetArrayRank();
@@ -85,6 +86,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = type.GetGenericArguments()[0];
             var arrayGenerator = context.GetGenerator(elemType.MakeArrayType());
 
@@ -109,6 +111,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = type.GetGenericArguments()[0];
             var generator = context.GetGenerator(elemType);
 
@@ -143,6 +146,7 @@ namespace RandomFixtureKit.Generators
             var valueType = genArgs[1];
             var keyGenerator = context.GetGenerator(keyType);
             var valueGenerator = context.GetGenerator(valueType);
+            context.TypeStack.Enter(Type);
 
             var dict = ReflectionHelper.CreateInstance(type) as IDictionary;
             for (int i = 0; i < length; i++)
@@ -169,6 +173,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var elemType = Type.GetGenericArguments()[0];
             var generator = context.GetGenerator(elemType);
 
@@ -249,6 +254,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
+            context.TypeStack.Enter(Type);
             var genType = type.GenericTypeArguments;
             var generator = context.GetGenerator(typeof(Dictionary<,>).MakeGenericType(new[] { genType[0], genType[1].MakeArrayType() }));
             var dictionary = generator.Generate(context);

--- a/src/RandomFixtureKit/Generators/ObjectGenerator.cs
+++ b/src/RandomFixtureKit/Generators/ObjectGenerator.cs
@@ -19,8 +19,7 @@ namespace RandomFixtureKit.Generators
 
         public object Generate(in GenerationContext context)
         {
-            var scope = context.TypeStack.Enter(type);
-            try
+            using (var scope = context.TypeStack.Enter(type))
             {
                 var obj = FormatterServices.GetUninitializedObject(type);
 
@@ -37,10 +36,6 @@ namespace RandomFixtureKit.Generators
                 }
 
                 return obj;
-            }
-            finally
-            {
-                scope.Dispose();
             }
         }
     }

--- a/src/RandomFixtureKit/Interfaces.cs
+++ b/src/RandomFixtureKit/Interfaces.cs
@@ -36,7 +36,7 @@ namespace RandomFixtureKit
         }
     }
 
-    public readonly ref struct TypeStack
+    public readonly struct TypeStack
     {
         readonly Stack<Type> stack;
 
@@ -63,7 +63,7 @@ namespace RandomFixtureKit
             return c;
         }
 
-        public readonly ref struct Exit // : IDisposable
+        public readonly struct Exit: IDisposable
         {
             readonly TypeStack parent;
 

--- a/src/RandomFixtureKit/Interfaces.cs
+++ b/src/RandomFixtureKit/Interfaces.cs
@@ -58,7 +58,7 @@ namespace RandomFixtureKit
             var c = 0;
             foreach (var item in stack)
             {
-                if (item == type) c++;
+                if (type.IsAssignableFrom(item)) c++;
             }
             return c;
         }

--- a/tests/RandomFixtureKit.Tests/RandomFixtureKit.Tests.csproj
+++ b/tests/RandomFixtureKit.Tests/RandomFixtureKit.Tests.csproj
@@ -20,4 +20,23 @@
     <ProjectReference Include="..\..\src\RandomFixtureKit\RandomFixtureKit.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TreeStructureTest.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>TreeStructureTest.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="TreeStructureTest.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>TreeStructureTest.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/tests/RandomFixtureKit.Tests/TreeStructureTest.cs
+++ b/tests/RandomFixtureKit.Tests/TreeStructureTest.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace RandomFixtureKit.Tests
+{
+    public class TreeStructureTest
+    {
+        [Fact]
+        public void CheckArray()
+        {
+            FixtureFactory.Create<ArrayTreeNode>();
+        }
+
+        [Fact]
+        public void CheckArraySegment() {
+            FixtureFactory.Create<ArraySegmentTreeNode>();
+        }
+
+        [Fact]
+        public void CheckList() {
+            FixtureFactory.Create<ListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckLinkedList() {
+            FixtureFactory.Create<LinkedListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckStack() {
+            FixtureFactory.Create<StackTreeNode>();
+        }
+
+        [Fact]
+        public void CheckQueue() {
+            FixtureFactory.Create<QueueTreeNode>();
+        }
+
+        [Fact]
+        public void CheckConcurrentQueue() {
+            FixtureFactory.Create<ConcurrentQueueTreeNode>();
+        }
+
+        [Fact]
+        public void CheckConcurrentStack() {
+            FixtureFactory.Create<ConcurrentStackTreeNode>();
+        }
+
+        [Fact]
+        public void CheckICollection() {
+            FixtureFactory.Create<ICollectionTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIEnumerable() {
+            FixtureFactory.Create<IEnumerableTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIList() {
+            FixtureFactory.Create<IListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIReadOnlyCollection() {
+            FixtureFactory.Create<IReadOnlyCollectionTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIReadOnlyList() {
+            FixtureFactory.Create<IReadOnlyListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckDictionary() {
+            FixtureFactory.Create<DictionaryTreeNode>();
+        }
+
+        [Fact]
+        public void CheckSortedDictionary() {
+            FixtureFactory.Create<SortedDictionaryTreeNode>();
+        }
+
+        [Fact]
+        public void CheckSortedList() {
+            FixtureFactory.Create<SortedListTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIDictionary() {
+            FixtureFactory.Create<IDictionaryTreeNode>();
+        }
+
+        [Fact]
+        public void CheckIReadOnlyDictionary() {
+            FixtureFactory.Create<IReadOnlyDictionaryTreeNode>();
+        }
+
+        }
+
+
+    class ArrayTreeNode
+    {
+        public string Name { get; set; }
+        public ArrayTreeNode[] Children { get; set; }
+    }
+
+    
+    class ArraySegmentTreeNode {
+        public string Name { get; set; }
+        public ArraySegment<ArraySegmentTreeNode> Children { get; set; }
+    }
+    
+    class ListTreeNode {
+        public string Name { get; set; }
+        public List<ListTreeNode> Children { get; set; }
+    }
+    
+    class LinkedListTreeNode {
+        public string Name { get; set; }
+        public LinkedList<LinkedListTreeNode> Children { get; set; }
+    }
+    
+    class StackTreeNode {
+        public string Name { get; set; }
+        public Stack<StackTreeNode> Children { get; set; }
+    }
+    
+    class QueueTreeNode {
+        public string Name { get; set; }
+        public Queue<QueueTreeNode> Children { get; set; }
+    }
+    
+    class ConcurrentQueueTreeNode {
+        public string Name { get; set; }
+        public ConcurrentQueue<ConcurrentQueueTreeNode> Children { get; set; }
+    }
+    
+    class ConcurrentStackTreeNode {
+        public string Name { get; set; }
+        public ConcurrentStack<ConcurrentStackTreeNode> Children { get; set; }
+    }
+    
+    class ICollectionTreeNode {
+        public string Name { get; set; }
+        public ICollection<ICollectionTreeNode> Children { get; set; }
+    }
+    
+    class IEnumerableTreeNode {
+        public string Name { get; set; }
+        public IEnumerable<IEnumerableTreeNode> Children { get; set; }
+    }
+    
+    class IListTreeNode {
+        public string Name { get; set; }
+        public IList<IListTreeNode> Children { get; set; }
+    }
+    
+    class IReadOnlyCollectionTreeNode {
+        public string Name { get; set; }
+        public IReadOnlyCollection<IReadOnlyCollectionTreeNode> Children { get; set; }
+    }
+    
+    class IReadOnlyListTreeNode {
+        public string Name { get; set; }
+        public IReadOnlyList<IReadOnlyListTreeNode> Children { get; set; }
+    }
+    
+    
+    class DictionaryTreeNode {
+        public string Name { get; set; }
+        public Dictionary<string, DictionaryTreeNode> Children { get; set; }
+    }
+    
+    class SortedDictionaryTreeNode {
+        public string Name { get; set; }
+        public SortedDictionary<string, SortedDictionaryTreeNode> Children { get; set; }
+    }
+    
+    class SortedListTreeNode {
+        public string Name { get; set; }
+        public SortedList<string, SortedListTreeNode> Children { get; set; }
+    }
+    
+    class IDictionaryTreeNode {
+        public string Name { get; set; }
+        public IDictionary<string, IDictionaryTreeNode> Children { get; set; }
+    }
+    
+    class IReadOnlyDictionaryTreeNode {
+        public string Name { get; set; }
+        public IReadOnlyDictionary<string, IReadOnlyDictionaryTreeNode> Children { get; set; }
+    }
+    }

--- a/tests/RandomFixtureKit.Tests/TreeStructureTest.tt
+++ b/tests/RandomFixtureKit.Tests/TreeStructureTest.tt
@@ -1,0 +1,80 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+	var collectionTypeNames = new[] {
+        "ArraySegment",
+        "List",
+        "LinkedList",
+        "Stack",
+        "Queue",
+        "ConcurrentQueue",
+        "ConcurrentStack",
+        "ICollection",
+        "IEnumerable",
+        "IList",
+        "IReadOnlyCollection",
+        "IReadOnlyList",
+	};
+
+    var dictionaryTypeNames = new[] {
+        "Dictionary",
+        "SortedDictionary",
+        "SortedList",
+        "IDictionary",
+        "IReadOnlyDictionary"
+    };
+#>
+using System;
+using FluentAssertions;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace RandomFixtureKit.Tests
+{
+    public class TreeStructureTest
+    {
+        [Fact]
+        public void CheckArray()
+        {
+            FixtureFactory.Create<ArrayTreeNode>();
+        }
+
+        <# foreach(var typeName in collectionTypeNames.Concat(dictionaryTypeNames)) { #>
+[Fact]
+        public void Check<#=typeName#>() {
+            FixtureFactory.Create<<#=typeName#>TreeNode>();
+        }
+
+        <# } #>}
+
+
+    class ArrayTreeNode
+    {
+        public string Name { get; set; }
+        public ArrayTreeNode[] Children { get; set; }
+    }
+
+    <# foreach(var typeName in collectionTypeNames) { #>
+
+    class <#=typeName#>TreeNode {
+        public string Name { get; set; }
+        public <#=typeName#><<#=typeName#>TreeNode> Children { get; set; }
+    }
+    <# } #>
+
+    <# foreach(var typeName in dictionaryTypeNames) { #>
+
+    class <#=typeName#>TreeNode {
+        public string Name { get; set; }
+        public <#=typeName#><string, <#=typeName#>TreeNode> Children { get; set; }
+    }
+    <# } #>
+}


### PR DESCRIPTION
I found a bug when I generating a tree-structure object.
It seemed that the recursive restriction didn't work because the `Array` type was not stacked at `CollectionGenerator.Generate` and `TypeStack.GetCount()` was missing to care about interface implementation.

So I fixed them. 
Please check diffs and merge if ok.