### PR TITLE
Drop .NET 3.1 support, and add .NET 6 support instead.

### DIFF
--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
## tl;dr;

.NET 3.1 had been EOL on 2022-12-13. Let's drop it and add .NET 6 (LTS) instead.

> https://dotnet.microsoft.com/ja-jp/platform/support/policy/dotnet-core